### PR TITLE
Export main to allow running it with deno run

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,10 @@
 {
   "name": "@frontside/staticalize",
-  "version": "0.1.0",
-  "exports": "./mod.ts",
+  "version": "0.2.0",
+  "exports": {
+    ".": "./mod.ts",
+    "./cli": "./main.ts"
+  },
   "license": "MIT",
   "tasks": {
     "dev": "deno run --watch main.ts",


### PR DESCRIPTION
## Motivation

I want to be able to run staticalize using `deno run` which requires the main module to be exported.

## Approach

Add `main.ts` as export under `cli`