### PR TITLE
✨ replace absolute `meta content="${url}"` properties with base url

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@frontside/staticalize",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "exports": {
     ".": "./mod.ts",
     "./cli": "./main.ts"

--- a/staticalize.ts
+++ b/staticalize.ts
@@ -159,6 +159,19 @@ function useDownloader(opts: DownloaderOptions): Operation<Downloader> {
                 }
               }
 
+              let withContents = selectAll("[content]", html);
+              for (let element of withContents) {
+                let attr = String(element.properties.content);
+                if (attr.startsWith(host.origin)) {
+                  yield* downloader.download(attr, source);
+                  let url = new URL(attr);
+                  url.host = base.host;
+                  url.port = base.port;
+                  url.protocol = base.protocol;
+                  element.properties.content = url.href;
+                }
+              }
+
               yield* call(async () => {
                 let destdir = dirname(destpath);
                 await ensureDir(destdir);

--- a/test/staticalize.test.ts
+++ b/test/staticalize.test.ts
@@ -193,13 +193,15 @@ describe("staticalize", () => {
 <html>
   <head>
     <link rel="canonical"  href="${host}"/>
-    <script src="${host}main.js"/>
+    <meta property="og:url" content="${host}image.png"/>
+    <script src="${host}main.js"></script>
   </head>
   <body></body>
 </html>
 `;
     app.get("/", (c) => c.html(html))
       .get("/alt", (c) => c.html(html))
+      .get("/image.png", (c) => c.text(""))
       .get("/main.js", (c) => c.text("console.log('hi')"))
       .get(...sitemap(["/"]));
 
@@ -214,6 +216,9 @@ describe("staticalize", () => {
     );
     await expect(content("test/dist/index.html")).resolves.toMatch(
       `<script src="https://fs.com/main.js">`,
+    );
+    await expect(content("test/dist/index.html")).resolves.toMatch(
+      `<meta property="og:url" content="https://fs.com/image.png">`,
     );
   });
 });


### PR DESCRIPTION
## Motivation

Currently if you have a meta tag with a content attribute reference that uses a self-referential url, it will leave in the url of the development server.

## Approach

This performs substitution on all tags with `content` attributes, but only if the content attribute starts with the absolute base url